### PR TITLE
DM-33226: Use config.load for ResourcePath

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dependencies = []
 [dependency-groups]
 dev = [
     "lsst-ctrl-execute",
+    # Until new ctrl-execute appears that can be pinned to support the
+    # pex_config changes, require the pex_config version
+    "lsst-pex-config >= 30.2026.300",
     "pre-commit>=4.0.1",
     "pytest",
     "pytest-cov",

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -10,7 +10,7 @@ def test_exec_config():
     exec_config_name = find_package_file("execConfig.py", platform="s3df")
 
     configuration = CondorConfig()
-    configuration.loadFromStream(exec_config_name)
+    configuration.load(exec_config_name)
     assert configuration.platform.scheduler == "slurm"
 
 
@@ -18,7 +18,7 @@ def test_allocation_config():
     slurm_config_name = find_package_file("slurmConfig.py", platform="s3df")
 
     configuration = AllocationConfig()
-    configuration.loadFromStream(slurm_config_name)
+    configuration.load(slurm_config_name)
     assert configuration.platform.queue == "$QUEUE"
 
 


### PR DESCRIPTION
Depends on lsst/pex_config#131